### PR TITLE
fix/32-aarch C2 compiler crash

### DIFF
--- a/ci_build_arch_aarch32.sh
+++ b/ci_build_arch_aarch32.sh
@@ -3,6 +3,7 @@ set -e
 
 export TARGET=arm-linux-androideabi
 export TARGET_JDK=arm
+export JVM_VARIANTS=client
 export NDK_PREBUILT_ARCH=/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/strip
 
 bash ci_build_global.sh


### PR DESCRIPTION
This patches the 32 aarch bug of android in java 8 when the C2 compiler fails mid-game and causes a crash this was patched by all the JRE'S 17, 21 & 25 *but not in Java 8 for some reason.*

This is done by setting the `JVM_VARIANTS` property to **client**.